### PR TITLE
Add master portfolios with child accounts

### DIFF
--- a/server/db/migrations/0001_broken_blazing_skull.sql
+++ b/server/db/migrations/0001_broken_blazing_skull.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `portfolios` ADD `parent_portfolio_id` text REFERENCES portfolios(id);

--- a/server/db/migrations/meta/0001_snapshot.json
+++ b/server/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,930 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c101ff84-1229-4443-8049-8b7816b32699",
+  "prevId": "989d3094-4083-49c9-9085-470494231f28",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assets": {
+      "name": "assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'stock'"
+        },
+        "exchange": {
+          "name": "exchange",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        }
+      },
+      "indexes": {
+        "assets_symbol_unique": {
+          "name": "assets_symbol_unique",
+          "columns": [
+            "symbol"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_configs": {
+      "name": "email_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "imap_host": {
+          "name": "imap_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imap_port": {
+          "name": "imap_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 993
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_portfolio_id": {
+          "name": "default_portfolio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "email_configs_user_idx": {
+          "name": "email_configs_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_configs_user_id_user_id_fk": {
+          "name": "email_configs_user_id_user_id_fk",
+          "tableFrom": "email_configs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_configs_default_portfolio_id_portfolios_id_fk": {
+          "name": "email_configs_default_portfolio_id_portfolios_id_fk",
+          "tableFrom": "email_configs",
+          "tableTo": "portfolios",
+          "columnsFrom": [
+            "default_portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_logs": {
+      "name": "email_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_config_id": {
+          "name": "email_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transactions_created": {
+          "name": "transactions_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_logs_user_id_user_id_fk": {
+          "name": "email_logs_user_id_user_id_fk",
+          "tableFrom": "email_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_logs_email_config_id_email_configs_id_fk": {
+          "name": "email_logs_email_config_id_email_configs_id_fk",
+          "tableFrom": "email_logs",
+          "tableTo": "email_configs",
+          "columnsFrom": [
+            "email_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "portfolios": {
+      "name": "portfolios",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_portfolio_id": {
+          "name": "parent_portfolio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "portfolios_user_id_user_id_fk": {
+          "name": "portfolios_user_id_user_id_fk",
+          "tableFrom": "portfolios",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolios_parent_portfolio_id_portfolios_id_fk": {
+          "name": "portfolios_parent_portfolio_id_portfolios_id_fk",
+          "tableFrom": "portfolios",
+          "tableTo": "portfolios",
+          "columnsFrom": [
+            "parent_portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "positions": {
+      "name": "positions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_cost_basis": {
+          "name": "avg_cost_basis",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "realized_pl": {
+          "name": "realized_pl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "positions_portfolio_asset_idx": {
+          "name": "positions_portfolio_asset_idx",
+          "columns": [
+            "portfolio_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "positions_portfolio_id_portfolios_id_fk": {
+          "name": "positions_portfolio_id_portfolios_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "portfolios",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "positions_asset_id_assets_id_fk": {
+          "name": "positions_asset_id_assets_id_fk",
+          "tableFrom": "positions",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fees": {
+          "name": "fees",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strike_price": {
+          "name": "strike_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "option_type": {
+          "name": "option_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_portfolio_id_portfolios_id_fk": {
+          "name": "transactions_portfolio_id_portfolios_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "portfolios",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_asset_id_assets_id_fk": {
+          "name": "transactions_asset_id_assets_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1772910534950,
       "tag": "0000_confused_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1773080767934,
+      "tag": "0001_broken_blazing_skull",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/queries/portfolios.ts
+++ b/server/db/queries/portfolios.ts
@@ -1,22 +1,53 @@
-import { and, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { db } from '../client.js';
 import { portfolios } from '../schema.js';
 
+type PortfolioMutation = {
+  name: string;
+  currency?: string;
+  parentPortfolioId?: string | null;
+};
+
+type PortfolioUpdate = Partial<{
+  name: string;
+  currency: string;
+  isDefault: boolean;
+  parentPortfolioId: string | null;
+}>;
+
 export const portfolioQueries = {
   list: (userId: string) =>
-    db.select().from(portfolios).where(eq(portfolios.userId, userId)),
+    db.select()
+      .from(portfolios)
+      .where(eq(portfolios.userId, userId))
+      .orderBy(asc(portfolios.parentPortfolioId), asc(portfolios.name)),
 
   get: (id: string) =>
     db.select().from(portfolios).where(eq(portfolios.id, id)).get(),
 
-  create: (userId: string, data: { name: string; currency?: string }) =>
+  create: (userId: string, data: PortfolioMutation) =>
     db.insert(portfolios).values({ userId, ...data }).returning().get(),
 
-  update: (id: string, data: Partial<{ name: string; currency: string; isDefault: boolean }>) =>
+  update: (id: string, data: PortfolioUpdate) =>
     db.update(portfolios).set(data).where(eq(portfolios.id, id)).returning().get(),
 
   delete: (id: string) =>
     db.delete(portfolios).where(eq(portfolios.id, id)),
+
+  listChildren: (parentPortfolioId: string) =>
+    db.select()
+      .from(portfolios)
+      .where(eq(portfolios.parentPortfolioId, parentPortfolioId))
+      .orderBy(asc(portfolios.name)),
+
+  hasChildren: async (parentPortfolioId: string) => {
+    const child = await db.select({ id: portfolios.id })
+      .from(portfolios)
+      .where(eq(portfolios.parentPortfolioId, parentPortfolioId))
+      .limit(1)
+      .get();
+    return Boolean(child);
+  },
 
   setDefault: async (userId: string, portfolioId: string) => {
     // Clear existing default

--- a/server/db/queries/positions.ts
+++ b/server/db/queries/positions.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, notInArray } from 'drizzle-orm';
+import { and, eq, inArray, ne, notInArray } from 'drizzle-orm';
 import { db } from '../client.js';
 import { assets, positions } from '../schema.js';
 
@@ -20,6 +20,26 @@ export const positionQueries = {
       .from(positions)
       .innerJoin(assets, eq(positions.assetId, assets.id))
       .where(and(eq(positions.portfolioId, portfolioId), ne(positions.quantity, 0))),
+
+  listByPortfolioIds: async (portfolioIds: string[]) => {
+    if (portfolioIds.length === 0) return [];
+    return db.select({
+      id: positions.id,
+      portfolioId: positions.portfolioId,
+      assetId: positions.assetId,
+      quantity: positions.quantity,
+      avgCostBasis: positions.avgCostBasis,
+      realizedPl: positions.realizedPl,
+      updatedAt: positions.updatedAt,
+      symbol: assets.symbol,
+      assetName: assets.name,
+      assetType: assets.assetType,
+      currency: assets.currency,
+    })
+      .from(positions)
+      .innerJoin(assets, eq(positions.assetId, assets.id))
+      .where(and(inArray(positions.portfolioId, portfolioIds), ne(positions.quantity, 0)));
+  },
 
   get: (portfolioId: string, assetId: string) =>
     db.select()

--- a/server/db/queries/transactions.ts
+++ b/server/db/queries/transactions.ts
@@ -1,6 +1,6 @@
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray } from 'drizzle-orm';
 import { db } from '../client.js';
-import { assets, transactions } from '../schema.js';
+import { assets, portfolios, transactions } from '../schema.js';
 
 type TransactionUpdate = Partial<Pick<typeof transactions.$inferInsert,
   'type' | 'quantity' | 'price' | 'fees' | 'date' | 'notes' | 'strikePrice' | 'expirationDate' | 'optionType'
@@ -23,14 +23,45 @@ export const transactionQueries = {
       optionType: transactions.optionType,
       source: transactions.source,
       createdAt: transactions.createdAt,
+      portfolioName: portfolios.name,
       symbol: assets.symbol,
       assetName: assets.name,
       assetType: assets.assetType,
     })
       .from(transactions)
       .innerJoin(assets, eq(transactions.assetId, assets.id))
+      .innerJoin(portfolios, eq(transactions.portfolioId, portfolios.id))
       .where(eq(transactions.portfolioId, portfolioId))
       .orderBy(desc(transactions.date), desc(transactions.createdAt)),
+
+  listByPortfolioIds: async (portfolioIds: string[]) => {
+    if (portfolioIds.length === 0) return [];
+    return db.select({
+      id: transactions.id,
+      portfolioId: transactions.portfolioId,
+      assetId: transactions.assetId,
+      type: transactions.type,
+      quantity: transactions.quantity,
+      price: transactions.price,
+      fees: transactions.fees,
+      date: transactions.date,
+      notes: transactions.notes,
+      strikePrice: transactions.strikePrice,
+      expirationDate: transactions.expirationDate,
+      optionType: transactions.optionType,
+      source: transactions.source,
+      createdAt: transactions.createdAt,
+      portfolioName: portfolios.name,
+      symbol: assets.symbol,
+      assetName: assets.name,
+      assetType: assets.assetType,
+    })
+      .from(transactions)
+      .innerJoin(assets, eq(transactions.assetId, assets.id))
+      .innerJoin(portfolios, eq(transactions.portfolioId, portfolios.id))
+      .where(inArray(transactions.portfolioId, portfolioIds))
+      .orderBy(desc(transactions.date), desc(transactions.createdAt));
+  },
 
   get: (id: string) =>
     db.select().from(transactions).where(eq(transactions.id, id)).get(),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import {
+  foreignKey,
   integer,
   real,
   sqliteTable,
@@ -63,10 +64,16 @@ export const portfolios = sqliteTable('portfolios', {
   id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
   userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
+  parentPortfolioId: text('parent_portfolio_id'),
   currency: text('currency').notNull().default('USD'),
   isDefault: integer('is_default', { mode: 'boolean' }).notNull().default(false),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(unixepoch())`),
-});
+}, (t) => [
+  foreignKey({
+    columns: [t.parentPortfolioId],
+    foreignColumns: [t.id],
+  }).onDelete('cascade'),
+]);
 
 // ---------------------------------------------------------------------------
 // Assets (financial instruments)

--- a/server/lib/emailProcessor.test.ts
+++ b/server/lib/emailProcessor.test.ts
@@ -54,11 +54,11 @@ describe('emailProcessor account routing', () => {
 
     const portfolioId = await resolvePortfolioIdForAccount({
       userId: 'user-1',
-      fallbackPortfolioId: 'fallback-portfolio',
+      importRootPortfolioId: 'root-portfolio',
       portfolioIdsByKey,
     });
 
-    expect(portfolioId).toBe('fallback-portfolio');
+    expect(portfolioId).toBe('root-portfolio');
     expect(portfolioQueries.create).not.toHaveBeenCalled();
   });
 
@@ -67,7 +67,7 @@ describe('emailProcessor account routing', () => {
 
     const portfolioId = await resolvePortfolioIdForAccount({
       userId: 'user-1',
-      fallbackPortfolioId: 'fallback-portfolio',
+      importRootPortfolioId: 'root-portfolio',
       accountName: '  TFSA  ',
       portfolioIdsByKey,
     });
@@ -82,6 +82,7 @@ describe('emailProcessor account routing', () => {
       userId: 'user-1',
       name: 'RRSP',
       currency: 'USD',
+      parentPortfolioId: 'root-portfolio',
       isDefault: false,
       createdAt: new Date(),
     });
@@ -90,13 +91,16 @@ describe('emailProcessor account routing', () => {
 
     const portfolioId = await resolvePortfolioIdForAccount({
       userId: 'user-1',
-      fallbackPortfolioId: 'fallback-portfolio',
+      importRootPortfolioId: 'root-portfolio',
       accountName: 'RRSP',
       portfolioIdsByKey,
     });
 
     expect(portfolioId).toBe('portfolio-2');
-    expect(portfolioQueries.create).toHaveBeenCalledWith('user-1', { name: 'RRSP' });
+    expect(portfolioQueries.create).toHaveBeenCalledWith('user-1', {
+      name: 'RRSP',
+      parentPortfolioId: 'root-portfolio',
+    });
     expect(portfolioIdsByKey.get(normalizePortfolioKey('RRSP'))).toBe('portfolio-2');
   });
 });

--- a/server/lib/emailProcessor.ts
+++ b/server/lib/emailProcessor.ts
@@ -26,41 +26,49 @@ export function normalizePortfolioKey(name: string): string {
 
 export async function resolvePortfolioIdForAccount(params: {
   userId: string;
-  fallbackPortfolioId: string;
+  importRootPortfolioId: string;
   accountName?: string;
   portfolioIdsByKey: Map<string, string>;
 }): Promise<string> {
-  const { userId, fallbackPortfolioId, accountName, portfolioIdsByKey } = params;
+  const { userId, importRootPortfolioId, accountName, portfolioIdsByKey } = params;
 
-  if (!accountName) return fallbackPortfolioId;
+  if (!accountName) return importRootPortfolioId;
 
   const normalizedAccountName = normalizePortfolioKey(accountName);
   const existingPortfolioId = portfolioIdsByKey.get(normalizedAccountName);
   if (existingPortfolioId) return existingPortfolioId;
 
-  const createdPortfolio = await portfolioQueries.create(userId, { name: accountName.trim() });
+  const createdPortfolio = await portfolioQueries.create(userId, {
+    name: accountName.trim(),
+    parentPortfolioId: importRootPortfolioId,
+  });
   if (!createdPortfolio) {
-    throw new Error(`Failed to create portfolio for account "${accountName}"`);
+    throw new Error(`Failed to create account "${accountName}"`);
   }
 
   portfolioIdsByKey.set(normalizedAccountName, createdPortfolio.id);
   return createdPortfolio.id;
 }
 
-export async function syncEmails(userId: string, fallbackPortfolioId: string, options: SyncOptions = {}): Promise<SyncResult> {
+export async function syncEmails(userId: string, importRootPortfolioId: string, options: SyncOptions = {}): Promise<SyncResult> {
   const config = emailConfigQueries.getByUser(userId);
   if (!config) throw new Error('No email configuration found');
 
   const result: SyncResult = { processed: 0, created: 0, failed: 0, errors: [] };
-  const existingPortfolios = await portfolioQueries.list(userId);
+  const existingPortfolios = await portfolioQueries.listChildren(importRootPortfolioId);
   const portfolioIdsByKey = new Map(
     existingPortfolios.map((portfolio) => [normalizePortfolioKey(portfolio.name), portfolio.id])
   );
-  const hasDefaultPortfolio = existingPortfolios.some((portfolio) => portfolio.isDefault);
+  const importRootPortfolio = portfolioQueries.get(importRootPortfolioId);
+  if (!importRootPortfolio || importRootPortfolio.userId !== userId) {
+    throw new Error('Import root portfolio not found');
+  }
+
+  const allPortfolios = await portfolioQueries.list(userId);
+  const hasDefaultPortfolio = allPortfolios.some((portfolio) => portfolio.isDefault);
   const hasPriorEmailLogs = (await emailConfigQueries.getLogs(userId, 1)).length > 0;
   const includeSeen = options.includeSeen ?? !hasPriorEmailLogs;
   const affectedPortfolioIds = new Set<string>();
-  const createdByPortfolioId = new Map<string, number>();
 
   const client = new ImapFlow({
     host: config.imapHost,
@@ -125,7 +133,7 @@ export async function syncEmails(userId: string, fallbackPortfolioId: string, op
           for (const tx of transactions) {
             const targetPortfolioId = await resolvePortfolioIdForAccount({
               userId,
-              fallbackPortfolioId,
+              importRootPortfolioId,
               accountName: tx.accountName,
               portfolioIdsByKey,
             });
@@ -142,7 +150,6 @@ export async function syncEmails(userId: string, fallbackPortfolioId: string, op
               source: 'email',
             });
             affectedPortfolioIds.add(targetPortfolioId);
-            createdByPortfolioId.set(targetPortfolioId, (createdByPortfolioId.get(targetPortfolioId) ?? 0) + 1);
             created++;
           }
 
@@ -195,11 +202,14 @@ export async function syncEmails(userId: string, fallbackPortfolioId: string, op
 
   // Recalculate positions once after all emails are processed
   if (result.created > 0) {
-    result.primaryImportedPortfolioId = [...createdByPortfolioId.entries()]
-      .sort((a, b) => b[1] - a[1])[0]?.[0];
+    result.primaryImportedPortfolioId = importRootPortfolio.id;
 
-    if (result.primaryImportedPortfolioId && !hasDefaultPortfolio) {
-      await portfolioQueries.setDefault(userId, result.primaryImportedPortfolioId);
+    if (!hasDefaultPortfolio) {
+      await portfolioQueries.setDefault(userId, importRootPortfolio.id);
+    }
+
+    if (affectedPortfolioIds.size === 0) {
+      affectedPortfolioIds.add(importRootPortfolio.id);
     }
 
     for (const portfolioId of affectedPortfolioIds) {

--- a/server/lib/portfolioScope.ts
+++ b/server/lib/portfolioScope.ts
@@ -1,0 +1,32 @@
+import { portfolioQueries } from '../db/queries/portfolios.js';
+
+type PortfolioRecord = NonNullable<ReturnType<typeof portfolioQueries.get>>;
+
+export interface PortfolioScope {
+  portfolio: PortfolioRecord;
+  portfolioIds: string[];
+  childPortfolios: Awaited<ReturnType<typeof portfolioQueries.listChildren>>;
+  isAggregate: boolean;
+}
+
+export async function getPortfolioScope(userId: string, portfolioId: string): Promise<PortfolioScope | null> {
+  const portfolio = portfolioQueries.get(portfolioId);
+  if (!portfolio || portfolio.userId !== userId) return null;
+
+  if (portfolio.parentPortfolioId) {
+    return {
+      portfolio,
+      portfolioIds: [portfolio.id],
+      childPortfolios: [],
+      isAggregate: false,
+    };
+  }
+
+  const childPortfolios = await portfolioQueries.listChildren(portfolio.id);
+  return {
+    portfolio,
+    portfolioIds: [portfolio.id, ...childPortfolios.map((child) => child.id)],
+    childPortfolios,
+    isAggregate: childPortfolios.length > 0,
+  };
+}

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -66,6 +66,7 @@ app.post('/email-sync', async (c) => {
   const { portfolioId } = await c.req.json<{ portfolioId: string }>();
   const portfolio = portfolioQueries.get(portfolioId);
   if (!portfolio || portfolio.userId !== user.id) return c.json({ error: 'Not found' }, 404);
+  const importRootPortfolioId = portfolio.parentPortfolioId ?? portfolio.id;
 
   // Prevent duplicate syncs
   if (syncStore.isActive(user.id)) {
@@ -73,10 +74,10 @@ app.post('/email-sync', async (c) => {
   }
 
   // Initialize sync task
-  syncStore.start(user.id, portfolioId);
+  syncStore.start(user.id, importRootPortfolioId);
 
   // Run sync in background (don't await)
-  syncEmails(user.id, portfolioId).catch((err) => {
+  syncEmails(user.id, importRootPortfolioId).catch((err) => {
     syncStore.update(user.id, {
       status: 'error',
       errors: [err instanceof Error ? err.message : String(err)],

--- a/server/routes/portfolios.test.ts
+++ b/server/routes/portfolios.test.ts
@@ -10,6 +10,7 @@ vi.mock('../db/queries/portfolios.js', () => ({
     create: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
+    hasChildren: vi.fn(),
     setDefault: vi.fn(),
   },
 }));
@@ -43,6 +44,7 @@ describe('portfolio routes', () => {
       id: 'portfolio-2',
       userId: 'another-user',
       name: 'Foreign',
+      parentPortfolioId: null,
       currency: 'USD',
       isDefault: false,
       createdAt: new Date(),
@@ -60,6 +62,7 @@ describe('portfolio routes', () => {
       id: 'portfolio-1',
       userId: TEST_USER.id,
       name: 'Mine',
+      parentPortfolioId: null,
       currency: 'USD',
       isDefault: false,
       createdAt: new Date(),
@@ -68,6 +71,7 @@ describe('portfolio routes', () => {
       id: 'portfolio-1',
       userId: TEST_USER.id,
       name: 'Mine',
+      parentPortfolioId: null,
       currency: 'USD',
       isDefault: true,
       createdAt: new Date(),
@@ -78,5 +82,27 @@ describe('portfolio routes', () => {
 
     expect(response.status).toBe(200);
     expect(portfolioQueries.setDefault).toHaveBeenCalledWith(TEST_USER.id, 'portfolio-1');
+  });
+
+  it('rejects creating an account under another user portfolio', async () => {
+    vi.mocked(portfolioQueries.get).mockReturnValue({
+      id: 'portfolio-2',
+      userId: 'another-user',
+      name: 'Foreign',
+      parentPortfolioId: null,
+      currency: 'USD',
+      isDefault: false,
+      createdAt: new Date(),
+    });
+
+    const app = createApp();
+    const response = await app.request('/portfolios', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'TFSA', parentPortfolioId: 'portfolio-2' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(portfolioQueries.create).not.toHaveBeenCalled();
   });
 });

--- a/server/routes/portfolios.ts
+++ b/server/routes/portfolios.ts
@@ -12,9 +12,26 @@ app.get('/', async (c) => {
 
 app.post('/', async (c) => {
   const user = c.get('user');
-  const { name, currency } = await c.req.json<{ name: string; currency?: string }>();
+  const { name, currency, parentPortfolioId } = await c.req.json<{
+    name: string;
+    currency?: string;
+    parentPortfolioId?: string;
+  }>();
   if (!name?.trim()) return c.json({ error: 'Name is required' }, 400);
-  const portfolio = await portfolioQueries.create(user.id, { name: name.trim(), currency });
+  if (parentPortfolioId) {
+    const parentPortfolio = portfolioQueries.get(parentPortfolioId);
+    if (!parentPortfolio || parentPortfolio.userId !== user.id) {
+      return c.json({ error: 'Parent portfolio not found' }, 404);
+    }
+    if (parentPortfolio.parentPortfolioId) {
+      return c.json({ error: 'Accounts can only be created under a master portfolio' }, 400);
+    }
+  }
+  const portfolio = await portfolioQueries.create(user.id, {
+    name: name.trim(),
+    currency,
+    parentPortfolioId: parentPortfolioId ?? null,
+  });
   return c.json(portfolio, 201);
 });
 
@@ -33,6 +50,9 @@ app.delete('/:id', async (c) => {
   const id = c.req.param('id');
   const existing = portfolioQueries.get(id);
   if (!existing || existing.userId !== user.id) return c.json({ error: 'Not found' }, 404);
+  if (await portfolioQueries.hasChildren(id)) {
+    return c.json({ error: 'Delete child accounts before removing this master portfolio' }, 400);
+  }
   await portfolioQueries.delete(id);
   return c.json({ success: true });
 });

--- a/server/routes/positions.test.ts
+++ b/server/routes/positions.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { AuthUser } from '../middleware/requireAuth.js';
+
+vi.mock('../db/queries/positions.js', () => ({
+  positionQueries: {
+    list: vi.fn(),
+    listByPortfolioIds: vi.fn(),
+  },
+}));
+
+vi.mock('../db/queries/portfolios.js', () => ({
+  portfolioQueries: {
+    get: vi.fn(),
+    listChildren: vi.fn(),
+  },
+}));
+
+import { positionQueries } from '../db/queries/positions.js';
+import { portfolioQueries } from '../db/queries/portfolios.js';
+import positionsRouter from './positions.js';
+
+const TEST_USER: AuthUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'User',
+};
+
+function createApp() {
+  const app = new Hono<{ Variables: { user: AuthUser } }>();
+  app.use('*', async (c, next) => {
+    c.set('user', TEST_USER);
+    await next();
+  });
+  app.route('/positions', positionsRouter);
+  return app;
+}
+
+describe('positions routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('aggregates child account positions under a master portfolio', async () => {
+    vi.mocked(portfolioQueries.get).mockReturnValue({
+      id: 'master-1',
+      userId: TEST_USER.id,
+      name: 'Wealthsimple',
+      parentPortfolioId: null,
+      currency: 'USD',
+      isDefault: true,
+      createdAt: new Date(),
+    });
+    vi.mocked(portfolioQueries.listChildren).mockResolvedValue([
+      {
+        id: 'account-1',
+        userId: TEST_USER.id,
+        name: 'TFSA',
+        parentPortfolioId: 'master-1',
+        currency: 'USD',
+        isDefault: false,
+        createdAt: new Date(),
+      },
+      {
+        id: 'account-2',
+        userId: TEST_USER.id,
+        name: 'RRSP',
+        parentPortfolioId: 'master-1',
+        currency: 'USD',
+        isDefault: false,
+        createdAt: new Date(),
+      },
+    ]);
+    vi.mocked(positionQueries.listByPortfolioIds).mockResolvedValue([
+      {
+        id: 'pos-1',
+        portfolioId: 'account-1',
+        assetId: 'asset-1',
+        quantity: 10,
+        avgCostBasis: 100,
+        realizedPl: 25,
+        updatedAt: new Date('2026-03-01'),
+        symbol: 'AAPL',
+        assetName: 'Apple',
+        assetType: 'stock',
+        currency: 'USD',
+      },
+      {
+        id: 'pos-2',
+        portfolioId: 'account-2',
+        assetId: 'asset-1',
+        quantity: 5,
+        avgCostBasis: 120,
+        realizedPl: 15,
+        updatedAt: new Date('2026-03-02'),
+        symbol: 'AAPL',
+        assetName: 'Apple',
+        assetType: 'stock',
+        currency: 'USD',
+      },
+    ]);
+
+    const app = createApp();
+    const response = await app.request('/positions?portfolioId=master-1');
+
+    expect(response.status).toBe(200);
+    expect(positionQueries.listByPortfolioIds).toHaveBeenCalledWith(['master-1', 'account-1', 'account-2']);
+
+    const body = await response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      portfolioId: 'master-1',
+      assetId: 'asset-1',
+      quantity: 15,
+      realizedPl: 40,
+    });
+    expect(body[0].avgCostBasis).toBeCloseTo(106.6666666667, 10);
+  });
+});

--- a/server/routes/positions.ts
+++ b/server/routes/positions.ts
@@ -1,17 +1,45 @@
 import { Hono } from 'hono';
 import { positionQueries } from '../db/queries/positions.js';
-import { portfolioQueries } from '../db/queries/portfolios.js';
+import { getPortfolioScope } from '../lib/portfolioScope.js';
 import type { AuthUser } from '../middleware/requireAuth.js';
 
 const app = new Hono<{ Variables: { user: AuthUser } }>();
+
+function aggregatePositions(
+  portfolioId: string,
+  rows: Awaited<ReturnType<typeof positionQueries.listByPortfolioIds>>,
+) {
+  const byAssetId = new Map<string, (typeof rows)[number]>();
+
+  for (const row of rows) {
+    const existing = byAssetId.get(row.assetId);
+    if (!existing) {
+      byAssetId.set(row.assetId, { ...row, portfolioId });
+      continue;
+    }
+
+    const totalQuantity = existing.quantity + row.quantity;
+    const totalCostBasis = (existing.quantity * existing.avgCostBasis) + (row.quantity * row.avgCostBasis);
+    existing.quantity = totalQuantity;
+    existing.avgCostBasis = totalQuantity !== 0 ? totalCostBasis / totalQuantity : 0;
+    existing.realizedPl += row.realizedPl;
+    existing.updatedAt = existing.updatedAt > row.updatedAt ? existing.updatedAt : row.updatedAt;
+  }
+
+  return [...byAssetId.values()].filter((row) => row.quantity !== 0);
+}
 
 app.get('/', async (c) => {
   const user = c.get('user');
   const portfolioId = c.req.query('portfolioId');
   if (!portfolioId) return c.json({ error: 'portfolioId is required' }, 400);
-  const portfolio = portfolioQueries.get(portfolioId);
-  if (!portfolio || portfolio.userId !== user.id) return c.json({ error: 'Not found' }, 404);
-  const rows = await positionQueries.list(portfolioId);
+  const scope = await getPortfolioScope(user.id, portfolioId);
+  if (!scope) return c.json({ error: 'Not found' }, 404);
+
+  const rows = scope.isAggregate
+    ? aggregatePositions(scope.portfolio.id, await positionQueries.listByPortfolioIds(scope.portfolioIds))
+    : await positionQueries.list(scope.portfolio.id);
+
   return c.json(rows);
 });
 

--- a/server/routes/settings.test.ts
+++ b/server/routes/settings.test.ts
@@ -98,6 +98,7 @@ describe('settings routes', () => {
       id: 'portfolio-2',
       userId: 'another-user',
       name: 'Other',
+      parentPortfolioId: null,
       currency: 'USD',
       isDefault: false,
       createdAt: new Date(),

--- a/server/routes/transactions.ts
+++ b/server/routes/transactions.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { transactionQueries } from '../db/queries/transactions.js';
 import { portfolioQueries } from '../db/queries/portfolios.js';
 import { recalcPositions, ensureAsset } from '../lib/positions.js';
+import { getPortfolioScope } from '../lib/portfolioScope.js';
 import type { AuthUser } from '../middleware/requireAuth.js';
 
 const app = new Hono<{ Variables: { user: AuthUser } }>();
@@ -18,8 +19,11 @@ app.get('/', async (c) => {
   const user = c.get('user');
   const portfolioId = c.req.query('portfolioId');
   if (!portfolioId) return c.json({ error: 'portfolioId is required' }, 400);
-  if (!await ownedPortfolio(user.id, portfolioId)) return c.json({ error: 'Not found' }, 404);
-  const rows = await transactionQueries.list(portfolioId);
+  const scope = await getPortfolioScope(user.id, portfolioId);
+  if (!scope) return c.json({ error: 'Not found' }, 404);
+  const rows = scope.isAggregate
+    ? await transactionQueries.listByPortfolioIds(scope.portfolioIds)
+    : await transactionQueries.list(scope.portfolio.id);
   return c.json(rows);
 });
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,6 +15,7 @@ const navItems = [
 export function Layout() {
   const { portfolios, activePortfolioId, setActivePortfolio } = usePortfolioStore();
   const { user, setUser } = useAuthStore();
+  const masterPortfolios = portfolios.filter((portfolio) => !portfolio.parentPortfolioId);
 
   async function signOut() {
     await api.post('/auth/sign-out', {});
@@ -38,9 +39,15 @@ export function Layout() {
               onChange={(e) => setActivePortfolio(e.target.value)}
               className="w-full appearance-none rounded-md border border-zinc-200 bg-zinc-50 py-2 pl-3 pr-8 text-sm text-zinc-900 outline-none focus:border-indigo-400 focus:ring-1 focus:ring-indigo-200"
             >
-              {portfolios.map((p) => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
+              {masterPortfolios.flatMap((masterPortfolio) => {
+                const childAccounts = portfolios.filter((portfolio) => portfolio.parentPortfolioId === masterPortfolio.id);
+                return [
+                  <option key={masterPortfolio.id} value={masterPortfolio.id}>{masterPortfolio.name}</option>,
+                  ...childAccounts.map((account) => (
+                    <option key={account.id} value={account.id}>- {account.name}</option>
+                  )),
+                ];
+              })}
               {portfolios.length === 0 && <option value="">No portfolios</option>}
             </select>
             <ChevronDown size={14} className="pointer-events-none absolute right-2.5 top-2.5 text-zinc-400" />

--- a/src/features/import/EmailImport.tsx
+++ b/src/features/import/EmailImport.tsx
@@ -10,7 +10,8 @@ import type { Portfolio, SyncTask } from '../../types/index.js';
 
 export function EmailImport() {
   const { portfolios, activePortfolioId, setPortfolios, setActivePortfolio } = usePortfolioStore();
-  const [portfolioId, setPortfolioId] = useState(activePortfolioId ?? '');
+  const masterPortfolios = portfolios.filter((portfolio) => !portfolio.parentPortfolioId);
+  const [portfolioId, setPortfolioId] = useState('');
   const [syncTask, setSyncTask] = useState<SyncTask | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
@@ -19,6 +20,16 @@ export function EmailImport() {
   const appliedSyncRef = useRef<number | null>(null);
 
   const isActive = syncTask?.status === 'connecting' || syncTask?.status === 'syncing';
+
+  useEffect(() => {
+    const activePortfolio = portfolios.find((portfolio) => portfolio.id === activePortfolioId);
+    const nextPortfolioId = activePortfolio?.parentPortfolioId ?? activePortfolio?.id ?? masterPortfolios[0]?.id ?? '';
+    setPortfolioId((current) => (
+      current && masterPortfolios.some((portfolio) => portfolio.id === current)
+        ? current
+        : nextPortfolioId
+    ));
+  }, [activePortfolioId, masterPortfolios, portfolios]);
 
   const applyCompletedSync = useCallback(async (task: SyncTask) => {
     if (task.status !== 'done' || task.created === 0) return;
@@ -115,16 +126,16 @@ export function EmailImport() {
           <div>
             <h2 className="text-sm font-semibold text-zinc-900">Email Sync</h2>
             <p className="mt-1 text-xs text-zinc-500">
-              Connect your broker email in Settings first. Emails that include an account name will import into a matching portfolio automatically. The selected portfolio below is only used as a fallback.
+              Connect your broker email in Settings first. Select the master portfolio that should own this import. Each broker account detected from email will be created as a child account under that master portfolio.
             </p>
           </div>
         </div>
 
         <Select
-          label="Fallback portfolio"
+          label="Master portfolio"
           value={portfolioId}
           onChange={(e) => setPortfolioId(e.target.value)}
-          options={portfolios.map((p) => ({ value: p.id, label: p.name }))}
+          options={masterPortfolios.map((portfolio) => ({ value: portfolio.id, label: portfolio.name }))}
           className="mb-4"
         />
 

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ const emptyEmailForm = {
 export function SettingsPage() {
   const qc = useQueryClient();
   const { portfolios, setPortfolios } = usePortfolioStore();
+  const masterPortfolios = portfolios.filter((portfolio) => !portfolio.parentPortfolioId);
 
   // Portfolio management
   const [newPortfolioName, setNewPortfolioName] = useState('');
@@ -65,19 +66,53 @@ export function SettingsPage() {
 
       {/* Portfolios */}
       <section className="rounded-xl border border-zinc-200 bg-white p-5">
-        <h2 className="mb-4 text-sm font-semibold text-zinc-900">Portfolios</h2>
+        <h2 className="mb-1 text-sm font-semibold text-zinc-900">Master Portfolios</h2>
+        <p className="mb-4 text-xs text-zinc-500">
+          Create top-level portfolios here. Email sync will add detected broker accounts as child accounts under the selected master portfolio.
+        </p>
         <div className="space-y-2 mb-4">
-          {portfolios.map((p) => (
-            <div key={p.id} className="flex items-center justify-between rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2">
-              <span className="text-sm text-zinc-900">{p.name}</span>
-              <button
-                onClick={() => { if (confirm(`Delete "${p.name}"?`)) deletePortfolio.mutate(p.id); }}
-                className="text-zinc-400 hover:text-red-600 transition-colors"
-              >
-                <Trash2 size={14} />
-              </button>
-            </div>
-          ))}
+          {masterPortfolios.map((portfolio) => {
+            const childAccounts = portfolios.filter((item) => item.parentPortfolioId === portfolio.id);
+
+            return (
+              <div key={portfolio.id} className="rounded-lg border border-zinc-100 bg-zinc-50">
+                <div className="flex items-center justify-between px-3 py-2">
+                  <div>
+                    <span className="text-sm font-medium text-zinc-900">{portfolio.name}</span>
+                    <p className="text-xs text-zinc-500">
+                      {childAccounts.length === 0 ? 'No child accounts yet' : `${childAccounts.length} child account${childAccounts.length === 1 ? '' : 's'}`}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => { if (confirm(`Delete "${portfolio.name}"?`)) deletePortfolio.mutate(portfolio.id); }}
+                    className="text-zinc-400 hover:text-red-600 transition-colors"
+                    title={childAccounts.length > 0 ? 'Delete child accounts first' : 'Delete portfolio'}
+                    disabled={childAccounts.length > 0 || deletePortfolio.isPending}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+                {childAccounts.length > 0 && (
+                  <div className="border-t border-zinc-100 px-3 py-2">
+                    <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-zinc-400">Accounts</p>
+                    <div className="space-y-1">
+                      {childAccounts.map((account) => (
+                        <div key={account.id} className="flex items-center justify-between rounded-md bg-white px-3 py-2">
+                          <span className="text-sm text-zinc-700">{account.name}</span>
+                          <button
+                            onClick={() => { if (confirm(`Delete account "${account.name}"?`)) deletePortfolio.mutate(account.id); }}
+                            className="text-zinc-400 hover:text-red-600 transition-colors"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
         <form
           onSubmit={(e) => { e.preventDefault(); createPortfolio.mutate(); }}
@@ -86,7 +121,7 @@ export function SettingsPage() {
           <Input
             value={newPortfolioName}
             onChange={(e) => setNewPortfolioName(e.target.value)}
-            placeholder="New portfolio name"
+            placeholder="New master portfolio name"
             className="flex-1"
           />
           <Button type="submit" size="sm" loading={createPortfolio.isPending}>

--- a/src/features/transactions/TransactionsPage.tsx
+++ b/src/features/transactions/TransactionsPage.tsx
@@ -38,6 +38,7 @@ export function TransactionsPage() {
   function openAdd() { setEditing(null); setFormOpen(true); }
   function openEdit(tx: Transaction) { setEditing(tx); setFormOpen(true); }
   function onFormDone() { setFormOpen(false); setEditing(null); }
+  const showAccountColumn = new Set(transactions.map((transaction) => transaction.portfolioId)).size > 1;
 
   if (!activePortfolioId) {
     return <div className="flex h-64 items-center justify-center"><p className="text-zinc-500">No portfolio selected.</p></div>;
@@ -65,6 +66,7 @@ export function TransactionsPage() {
                 <tr className="border-b border-zinc-200 text-xs text-zinc-500">
                   <th className="px-5 py-3 text-left font-medium">Date</th>
                   <th className="px-5 py-3 text-left font-medium">Symbol</th>
+                  {showAccountColumn && <th className="px-5 py-3 text-left font-medium">Account</th>}
                   <th className="px-5 py-3 text-left font-medium">Type</th>
                   <th className="px-5 py-3 text-right font-medium">Qty</th>
                   <th className="px-5 py-3 text-right font-medium">Price</th>
@@ -79,6 +81,7 @@ export function TransactionsPage() {
                   <tr key={tx.id} className="border-b border-zinc-50 last:border-0 hover:bg-zinc-50/50">
                     <td className="px-5 py-3 text-zinc-600">{formatDate(tx.date)}</td>
                     <td className="px-5 py-3 font-medium text-zinc-900">{tx.symbol}</td>
+                    {showAccountColumn && <td className="px-5 py-3 text-zinc-600">{tx.portfolioName}</td>}
                     <td className="px-5 py-3">
                       <Badge variant={typeBadge[tx.type] ?? 'zinc'}>{tx.type}</Badge>
                     </td>

--- a/src/stores/portfolioStore.ts
+++ b/src/stores/portfolioStore.ts
@@ -19,7 +19,9 @@ export const usePortfolioStore = create<PortfolioState>()(
         const current = get().activePortfolioId;
         // Auto-select default or first if current is gone
         const stillExists = portfolios.some((p) => p.id === current);
-        const defaultP = portfolios.find((p) => p.isDefault) ?? portfolios[0];
+        const defaultP = portfolios.find((p) => p.isDefault)
+          ?? portfolios.find((p) => !p.parentPortfolioId)
+          ?? portfolios[0];
         set({
           portfolios,
           activePortfolioId: stillExists ? current : (defaultP?.id ?? null),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export interface Portfolio {
   id: string;
   userId: string;
   name: string;
+  parentPortfolioId?: string | null;
   currency: string;
   isDefault: boolean;
   createdAt: string;
@@ -34,6 +35,7 @@ export type TransactionSource = 'manual' | 'csv' | 'email';
 export interface Transaction {
   id: string;
   portfolioId: string;
+  portfolioName: string;
   assetId: string;
   type: TransactionType;
   quantity: number;


### PR DESCRIPTION
## Summary
- add a parent/child portfolio hierarchy so a master portfolio can own imported accounts
- aggregate positions and transactions across child accounts when a master portfolio is selected
- route email imports into child accounts under the selected master and update the UI to reflect the hierarchy

## Testing
- npm run test
- npm run lint
- npm run type-check
- npm run build