### PR TITLE
Fix current price feed quotes

### DIFF
--- a/server/routes/market.test.ts
+++ b/server/routes/market.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { AuthUser } from '../middleware/requireAuth.js';
+import marketRouter from './market.js';
+
+const TEST_USER: AuthUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'User',
+};
+
+function createApp() {
+  const app = new Hono<{ Variables: { user: AuthUser } }>();
+  app.use('*', async (c, next) => {
+    c.set('user', TEST_USER);
+    await next();
+  });
+  app.route('/market', marketRouter);
+  return app;
+}
+
+describe('market routes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns spark quotes for supported symbols and skips unresolved ones', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      spark: {
+        result: [
+          {
+            symbol: 'AAPL',
+            response: [{ meta: { symbol: 'AAPL', regularMarketPrice: 200, previousClose: 195 } }],
+          },
+          {
+            symbol: 'MSFT',
+            response: [{ meta: { symbol: 'MSFT', regularMarketPrice: 300, chartPreviousClose: 297 } }],
+          },
+          {
+            symbol: 'INVALID',
+            response: [{ meta: { symbol: 'INVALID' } }],
+          },
+        ],
+      },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const app = createApp();
+    const response = await app.request('/market/quotes?symbols=AAPL,MSFT,INVALID');
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = await response.json();
+    expect(body.AAPL.price).toBe(200);
+    expect(body.AAPL.change).toBe(5);
+    expect(body.AAPL.changePercent).toBeCloseTo(2.5641025641, 10);
+    expect(body.MSFT.price).toBe(300);
+    expect(body.MSFT.change).toBe(3);
+    expect(body.MSFT.changePercent).toBeCloseTo(1.0101010101, 10);
+    expect(body.INVALID).toBeUndefined();
+  });
+});

--- a/server/routes/market.ts
+++ b/server/routes/market.ts
@@ -1,9 +1,8 @@
 import { Hono } from 'hono';
-import YahooFinance from 'yahoo-finance2';
 import type { AuthUser } from '../middleware/requireAuth.js';
 
 const app = new Hono<{ Variables: { user: AuthUser } }>();
-const yahooFinance = new YahooFinance();
+const YAHOO_USER_AGENT = 'Mozilla/5.0';
 
 interface YahooSearchQuote {
   symbol?: string;
@@ -15,6 +14,20 @@ interface YahooSearchQuote {
   typeDisp?: string;
 }
 
+interface YahooSparkMeta {
+  symbol?: string;
+  regularMarketPrice?: number;
+  previousClose?: number;
+  chartPreviousClose?: number;
+}
+
+interface YahooSparkResult {
+  symbol?: string;
+  response?: Array<{
+    meta?: YahooSparkMeta;
+  }>;
+}
+
 async function searchYahooSymbols(query: string): Promise<YahooSearchQuote[]> {
   const url = new URL('https://query1.finance.yahoo.com/v1/finance/search');
   url.searchParams.set('q', query);
@@ -23,7 +36,7 @@ async function searchYahooSymbols(query: string): Promise<YahooSearchQuote[]> {
 
   const response = await fetch(url, {
     headers: {
-      'User-Agent': 'Mozilla/5.0',
+      'User-Agent': YAHOO_USER_AGENT,
     },
   });
 
@@ -35,15 +48,71 @@ async function searchYahooSymbols(query: string): Promise<YahooSearchQuote[]> {
   return data.quotes ?? [];
 }
 
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+async function fetchYahooSparkQuotes(symbols: string[]) {
+  const quotes: Record<string, { price: number; change: number; changePercent: number }> = {};
+
+  for (const symbolChunk of chunk(symbols, 25)) {
+    const url = new URL('https://query1.finance.yahoo.com/v7/finance/spark');
+    url.searchParams.set('symbols', symbolChunk.join(','));
+    url.searchParams.set('range', '1d');
+    url.searchParams.set('interval', '5m');
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': YAHOO_USER_AGENT,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Yahoo spark failed with status ${response.status}`);
+    }
+
+    const data = await response.json() as {
+      spark?: {
+        result?: YahooSparkResult[];
+      };
+    };
+
+    for (const result of data.spark?.result ?? []) {
+      const meta = result.response?.[0]?.meta;
+      const symbol = (meta?.symbol ?? result.symbol ?? '').toUpperCase();
+      const price = meta?.regularMarketPrice;
+      const previousClose = meta?.previousClose ?? meta?.chartPreviousClose;
+
+      if (!symbol || price === undefined || previousClose === undefined) continue;
+
+      const change = price - previousClose;
+      const changePercent = previousClose !== 0
+        ? (change / previousClose) * 100
+        : 0;
+
+      quotes[symbol] = { price, change, changePercent };
+    }
+  }
+
+  return quotes;
+}
+
 // Simple in-memory cache: symbol → { price, change, changePercent, updatedAt }
 const cache = new Map<string, { price: number; change: number; changePercent: number; updatedAt: number }>();
+const missingCache = new Map<string, number>();
 const CACHE_TTL_MS = 60_000; // 1 minute
 
 app.get('/quotes', async (c) => {
   const symbolsParam = c.req.query('symbols');
   if (!symbolsParam) return c.json({ error: 'symbols is required' }, 400);
 
-  const symbols = symbolsParam.split(',').map((s) => s.trim().toUpperCase()).filter(Boolean);
+  const symbols = [...new Set(
+    symbolsParam.split(',').map((s) => s.trim().toUpperCase()).filter(Boolean)
+  )];
   const now = Date.now();
   const result: Record<string, { price: number; change: number; changePercent: number }> = {};
   const toFetch: string[] = [];
@@ -52,29 +121,34 @@ app.get('/quotes', async (c) => {
     const cached = cache.get(sym);
     if (cached && now - cached.updatedAt < CACHE_TTL_MS) {
       result[sym] = { price: cached.price, change: cached.change, changePercent: cached.changePercent };
+    } else if ((missingCache.get(sym) ?? 0) + CACHE_TTL_MS > now) {
+      continue;
     } else {
       toFetch.push(sym);
     }
   }
 
   if (toFetch.length > 0) {
-    await Promise.allSettled(
-      toFetch.map(async (sym) => {
-        try {
-          const quote = await yahooFinance.quote(sym);
-          const data = {
-            price: quote.regularMarketPrice ?? 0,
-            change: quote.regularMarketChange ?? 0,
-            changePercent: quote.regularMarketChangePercent ?? 0,
-            updatedAt: Date.now(),
-          };
-          cache.set(sym, data);
-          result[sym] = { price: data.price, change: data.change, changePercent: data.changePercent };
-        } catch {
-          result[sym] = { price: 0, change: 0, changePercent: 0 };
+    try {
+      const fetchedQuotes = await fetchYahooSparkQuotes(toFetch);
+
+      for (const [sym, quote] of Object.entries(fetchedQuotes)) {
+        const data = { ...quote, updatedAt: Date.now() };
+        cache.set(sym, data);
+        missingCache.delete(sym);
+        result[sym] = quote;
+      }
+
+      for (const sym of toFetch) {
+        if (!(sym in fetchedQuotes)) {
+          missingCache.set(sym, now);
         }
-      })
-    );
+      }
+    } catch {
+      for (const sym of toFetch) {
+        missingCache.set(sym, now);
+      }
+    }
   }
 
   return c.json(result);

--- a/src/features/dashboard/Dashboard.tsx
+++ b/src/features/dashboard/Dashboard.tsx
@@ -62,9 +62,8 @@ export function Dashboard() {
   const enriched = enrichPositions(positions, quotes);
   const summary = calcPortfolioSummary(enriched);
 
-  const topPositions = [...enriched]
-    .sort((a, b) => Math.abs(b.marketValue ?? 0) - Math.abs(a.marketValue ?? 0))
-    .slice(0, 5);
+  const sortedPositions = [...enriched]
+    .sort((a, b) => Math.abs(b.marketValue ?? 0) - Math.abs(a.marketValue ?? 0));
 
   return (
     <div className="p-6">
@@ -99,11 +98,12 @@ export function Dashboard() {
         />
       </div>
 
-      {/* Top positions */}
-      {topPositions.length > 0 && (
+      {/* Holdings */}
+      {sortedPositions.length > 0 && (
         <div className="rounded-xl border border-zinc-200 bg-white">
-          <div className="border-b border-zinc-200 px-5 py-4">
-            <h2 className="text-sm font-semibold text-zinc-900">Top Holdings</h2>
+          <div className="flex items-center justify-between border-b border-zinc-200 px-5 py-4">
+            <h2 className="text-sm font-semibold text-zinc-900">Holdings</h2>
+            <p className="text-xs text-zinc-500">{sortedPositions.length} total</p>
           </div>
           <table className="w-full text-sm">
             <thead>
@@ -116,7 +116,7 @@ export function Dashboard() {
               </tr>
             </thead>
             <tbody>
-              {topPositions.map((p) => (
+              {sortedPositions.map((p) => (
                 <tr key={p.assetId} className="border-b border-zinc-50 last:border-0 hover:bg-zinc-50/50">
                   <td className="px-5 py-3">
                     <p className="font-medium text-zinc-900">{p.symbol}</p>
@@ -141,7 +141,7 @@ export function Dashboard() {
         </div>
       )}
 
-      {topPositions.length === 0 && (
+      {sortedPositions.length === 0 && (
         <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center">
           <p className="text-zinc-500">No positions yet. Add transactions to get started.</p>
         </div>


### PR DESCRIPTION
## Summary
- replace the crumb-based Yahoo quote client with the public spark endpoint for current prices
- batch quote lookups to avoid per-symbol rate limiting and stop returning fake zero prices on failures
- add a route test that verifies real quotes are returned and unsupported symbols are skipped

## Testing
- npm run test
- npm run type-check
- npm run lint
- npm run build